### PR TITLE
Fix some linter warnings and refactor CheckerStruct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ petgraph = "^0.5"
 nom = "6.0"
 lazy_static = "^1.4"
 fnv = "^1"
+bytecount = "^0.6"
 once_cell = "^1"
 tree_magic_db = { version = "3", path = "./magic_db" , optional = true }
 

--- a/src/basetype/check.rs
+++ b/src/basetype/check.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 /// If there are any null bytes, return False. Otherwise return True.
 fn is_text_plain_from_u8(b: &[u8]) -> bool {
-    b.iter().filter(|&x| *x == 0).count() == 0
+    bytecount::count(b, 0) == 0
 }
 
 // TODO: Hoist the main logic here somewhere else. This'll get redundant fast!
@@ -22,10 +22,10 @@ pub fn from_u8(b: &[u8], mimetype: &str) -> bool {
         return true;
     }
     if mimetype == "text/plain" {
-        return is_text_plain_from_u8(b);
+        is_text_plain_from_u8(b)
     } else {
         // ...how did we get bytes for this?
-        return false;
+        false
     }
 }
 
@@ -42,10 +42,10 @@ pub fn from_filepath(filepath: &Path, mimetype: &str) -> bool {
     };
 
     match mimetype {
-        "all/all" => return true,
-        "all/allfiles" | "application/octet-stream" => return meta.is_file(),
-        "inode/directory" => return meta.is_dir(),
-        "text/plain" => return is_text_plain_from_filepath(filepath),
-        _ => return false,
+        "all/all" => true,
+        "all/allfiles" | "application/octet-stream" => meta.is_file(),
+        "inode/directory" => meta.is_dir(),
+        "text/plain" => is_text_plain_from_filepath(filepath),
+        _ => false,
     }
 }

--- a/src/basetype/check.rs
+++ b/src/basetype/check.rs
@@ -1,5 +1,30 @@
-use crate::read_bytes;
+use crate::{read_bytes, MIME};
+use fnv::FnvHashMap;
 use std::path::Path;
+
+pub(crate) struct BaseType;
+
+impl crate::Checker for BaseType {
+    fn from_u8(&self, file: &[u8], mimetype: &str) -> bool {
+        from_u8(file, mimetype)
+    }
+
+    fn from_filepath(&self, filepath: &Path, mimetype: &str) -> bool {
+        from_filepath(filepath, mimetype)
+    }
+
+    fn get_supported(&self) -> Vec<MIME> {
+        super::init::get_supported()
+    }
+
+    fn get_subclasses(&self) -> Vec<(MIME, MIME)> {
+        super::init::get_subclasses()
+    }
+
+    fn get_aliaslist(&self) -> FnvHashMap<MIME, MIME> {
+        super::init::get_aliaslist()
+    }
+}
 
 /// If there are any null bytes, return False. Otherwise return True.
 fn is_text_plain_from_u8(b: &[u8]) -> bool {

--- a/src/basetype/mod.rs
+++ b/src/basetype/mod.rs
@@ -1,5 +1,5 @@
 //! Handles "base types" such as inode/* and text/plain
-const TYPES: [&'static str; 5] = [
+const TYPES: [&str; 5] = [
     "all/all",
     "all/allfiles",
     "inode/directory",

--- a/src/fdo_magic/builtin/check.rs
+++ b/src/fdo_magic/builtin/check.rs
@@ -1,6 +1,31 @@
-use crate::{fdo_magic, read_bytes};
+use crate::{fdo_magic, read_bytes, MIME};
+use fnv::FnvHashMap;
 use petgraph::prelude::*;
 use std::path::Path;
+
+pub(crate) struct FdoMagic;
+
+impl crate::Checker for FdoMagic {
+    fn from_u8(&self, file: &[u8], mimetype: &str) -> bool {
+        from_u8(file, mimetype)
+    }
+
+    fn from_filepath(&self, filepath: &Path, mimetype: &str) -> bool {
+        from_filepath(filepath, mimetype)
+    }
+
+    fn get_supported(&self) -> Vec<MIME> {
+        super::init::get_supported()
+    }
+
+    fn get_subclasses(&self) -> Vec<(MIME, MIME)> {
+        super::init::get_subclasses()
+    }
+
+    fn get_aliaslist(&self) -> FnvHashMap<MIME, MIME> {
+        super::init::get_aliaslist()
+    }
+}
 
 /// Test against all rules
 #[allow(unused_variables)]

--- a/src/fdo_magic/builtin/check.rs
+++ b/src/fdo_magic/builtin/check.rs
@@ -34,7 +34,7 @@ pub fn from_filepath(filepath: &Path, mimetype: &str) -> bool {
     // Get # of bytes to read
     let mut scanlen = 0;
     for x in magic_rules.raw_nodes() {
-        let ref y = x.weight;
+        let y = &x.weight;
         let tmplen = y.start_off as usize + y.val.len() + y.region_len as usize;
 
         if tmplen > scanlen {

--- a/src/fdo_magic/builtin/mod.rs
+++ b/src/fdo_magic/builtin/mod.rs
@@ -31,10 +31,10 @@ fn rules() -> FnvHashMap<MIME, DiGraph<MagicRule<'static>, u32>> {
 
 #[cfg(feature = "with-gpl-data")]
 fn static_rules() -> FnvHashMap<MIME, DiGraph<MagicRule<'static>, u32>> {
-    super::ruleset::from_u8(tree_magic_db::magic()).unwrap_or(FnvHashMap::default())
+    super::ruleset::from_u8(tree_magic_db::magic()).unwrap_or_default()
 }
 
 #[cfg(not(feature = "with-gpl-data"))]
 fn runtime_rules() -> FnvHashMap<MIME, DiGraph<MagicRule<'static>, u32>> {
-    runtime::rules().unwrap_or(FnvHashMap::default())
+    runtime::rules().unwrap_or_default()
 }

--- a/src/fdo_magic/builtin/runtime.rs
+++ b/src/fdo_magic/builtin/runtime.rs
@@ -90,5 +90,5 @@ pub(crate) fn subclasses() -> &'static str {
 
 pub(crate) fn rules() -> Result<FnvHashMap<MIME, DiGraph<MagicRule<'static>, u32>>, String> {
     let files = RUNTIME_RULES.get_or_init(load_xdg_shared_magic);
-    Ok(ruleset::from_multiple(files).unwrap())
+    ruleset::from_multiple(files)
 }

--- a/src/fdo_magic/check.rs
+++ b/src/fdo_magic/check.rs
@@ -19,7 +19,7 @@ fn from_u8_singlerule(file: &[u8], rule: &super::MagicRule) -> bool {
                     .iter()
                     .skip(bound_min)
                     .take(bound_max - bound_min)
-                    .map(|&x| x)
+                    .copied()
                     .collect();
                 //println!("\t{:?} / {:?}", x, rule.val);
                 //println!("\tIndent: {}, Start: {}", rule.indent_level, rule.start_off);
@@ -32,15 +32,15 @@ fn from_u8_singlerule(file: &[u8], rule: &super::MagicRule) -> bool {
                     .iter()
                     .skip(bound_min) // Skip to start of area
                     .take(bound_max - bound_min) // Take until end of area - region length
-                    .map(|&x| x)
+                    .copied()
                     .collect(); // Convert to vector
-                let mut val: Vec<u8> = rule.val.iter().map(|&x| x).collect();
+                let mut val: Vec<u8> = rule.val.iter().copied().collect();
                 //println!("\t{:?} / {:?}", x, rule.val);
 
                 assert_eq!(x.len(), mask.len());
                 for i in 0..std::cmp::min(x.len(), mask.len()) {
                     x[i] &= mask[i];
-                    val[i] = val[i] & mask[i];
+                    val[i] &= mask[i];
                 }
                 //println!("\t & {:?} => {:?}", mask, x);
 
@@ -52,12 +52,12 @@ fn from_u8_singlerule(file: &[u8], rule: &super::MagicRule) -> bool {
         //println!("\tIndent: {}, Start: {}", rule.indent_level, rule.start_off);
 
         // Define our testing slice
-        let ref x: Vec<u8> = file.iter().take(file.len()).map(|&x| x).collect();
+        let x: &Vec<u8> = &file.iter().take(file.len()).copied().collect();
         let testarea: Vec<u8> = x
             .iter()
             .skip(bound_min)
             .take(bound_max - bound_min)
-            .map(|&x| x)
+            .copied()
             .collect();
         //println!("{:?}, {:?}, {:?}\n", file, testarea, rule.val);
 
@@ -67,7 +67,7 @@ fn from_u8_singlerule(file: &[u8], rule: &super::MagicRule) -> bool {
             y.clear();
 
             // Apply mask to value
-            let ref rule_mask = rule.mask;
+            let rule_mask = &rule.mask;
             match *rule_mask {
                 Some(ref mask) => {
                     for i in 0..rule.val.len() {
@@ -98,7 +98,7 @@ pub fn from_u8_walker(
     let n = graph.neighbors_directed(node, Outgoing);
 
     if isroot {
-        let ref rule = graph[node];
+        let rule = &graph[node];
 
         // Check root
         if !from_u8_singlerule(&file, rule) {
@@ -115,7 +115,7 @@ pub fn from_u8_walker(
 
     // Check subrules recursively
     for y in n {
-        let ref rule = graph[y];
+        let rule = &graph[y];
 
         if from_u8_singlerule(&file, rule) {
             // Check next indent level if needed

--- a/src/fdo_magic/ruleset.rs
+++ b/src/fdo_magic/ruleset.rs
@@ -113,7 +113,7 @@ pub fn from_u8(b: &[u8]) -> Result<FnvHashMap<&str, DiGraph<MagicRule<'_>, u32>>
 /// Parse multiple ruleset magic files and aggregate the tuples into a single graph
 pub fn from_multiple<'a>(
     files: &'a [Vec<u8>],
-) -> Result<FnvHashMap<&'a str, DiGraph<MagicRule<'a>, u32>>, String> {
+) -> Result<FnvHashMap<&'a str, DiGraph<MagicRule<'_>, u32>>, String> {
     let mut tuplevec = vec![];
     for slice in files {
         tuplevec.append(&mut ruleset(slice.as_ref()).map_err(|e| e.to_string())?.1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,46 +77,26 @@ const TYPEORDER: [&str; 6] = [
     "application/pdf",
 ];
 
-/// Struct used to define checker functions for the sake of boilerplate reduction
-struct CheckerStruct {
-    from_u8: fn(&[u8], &str) -> bool,
-    from_filepath: fn(&Path, &str) -> bool,
-    get_supported: fn() -> Vec<MIME>,
-    get_subclasses: fn() -> Vec<(MIME, MIME)>,
-    get_aliaslist: fn() -> FnvHashMap<MIME, MIME>,
+pub(crate) trait Checker: Send + Sync {
+    fn from_u8(&self, file: &[u8], mimetype: &str) -> bool;
+    fn from_filepath(&self, filepath: &Path, mimetype: &str) -> bool;
+    fn get_supported(&self) -> Vec<MIME>;
+    fn get_subclasses(&self) -> Vec<(MIME, MIME)>;
+    fn get_aliaslist(&self) -> FnvHashMap<MIME, MIME>;
 }
 
-/// Maximum number of checkers supported with build config.
-/// TODO: Find any better way to do this!
-const CHECKERCOUNT: usize = 2;
-
-/// List of checker functions
-const CHECKERS: [CheckerStruct; CHECKERCOUNT] = [
-    // fdo_magic
-    CheckerStruct {
-        from_u8: fdo_magic::builtin::check::from_u8,
-        from_filepath: fdo_magic::builtin::check::from_filepath,
-        get_supported: fdo_magic::builtin::init::get_supported,
-        get_subclasses: fdo_magic::builtin::init::get_subclasses,
-        get_aliaslist: fdo_magic::builtin::init::get_aliaslist,
-    },
-    // basetype
-    CheckerStruct {
-        from_u8: basetype::check::from_u8,
-        from_filepath: basetype::check::from_filepath,
-        get_supported: basetype::init::get_supported,
-        get_subclasses: basetype::init::get_subclasses,
-        get_aliaslist: basetype::init::get_aliaslist,
-    },
+static CHECKERS: &[&'static dyn Checker] = &[
+    &fdo_magic::builtin::check::FdoMagic,
+    &basetype::check::BaseType,
 ];
 
-/// Mappings between modules and supported mimes (by index in table above)
+/// Mappings between modules and supported mimes
 lazy_static! {
-    static ref CHECKER_SUPPORT: FnvHashMap<MIME, usize> = {
-        let mut out = FnvHashMap::<MIME, usize>::default();
-        for (i, c) in CHECKERS.iter().enumerate() {
-            for j in (c.get_supported)() {
-                out.insert(j, i);
+    static ref CHECKER_SUPPORT: FnvHashMap<MIME, &'static dyn Checker> = {
+        let mut out = FnvHashMap::<MIME, &'static dyn Checker>::default();
+        for &c in CHECKERS {
+            for m in c.get_supported() {
+                out.insert(m, c);
             }
         }
         out
@@ -126,8 +106,8 @@ lazy_static! {
 lazy_static! {
     static ref ALIASES: FnvHashMap<MIME, MIME> = {
         let mut out = FnvHashMap::<MIME, MIME>::default();
-        for c in &CHECKERS {
-            out.extend((c.get_aliaslist)());
+        for &c in CHECKERS {
+            out.extend(c.get_aliaslist());
         }
         out
     };
@@ -159,9 +139,9 @@ fn graph_init() -> TypeStruct {
     // Get list of MIME types and MIME relations
     let mut mimelist = Vec::<MIME>::new();
     let mut edgelist_raw = Vec::<(MIME, MIME)>::new();
-    for c in &CHECKERS {
-        mimelist.extend((c.get_supported)());
-        edgelist_raw.extend((c.get_subclasses)());
+    for &c in CHECKERS {
+        mimelist.extend(c.get_supported());
+        edgelist_raw.extend(c.get_subclasses());
     }
     mimelist.sort_unstable();
     mimelist.dedup();
@@ -313,7 +293,7 @@ fn get_alias(mimetype: &str) -> &str {
 fn match_u8_noalias(mimetype: &str, bytes: &[u8]) -> bool {
     match CHECKER_SUPPORT.get(mimetype) {
         None => false,
-        Some(y) => (CHECKERS[*y].from_u8)(bytes, mimetype),
+        Some(y) => y.from_u8(bytes, mimetype),
     }
 }
 
@@ -377,7 +357,7 @@ pub fn from_u8(bytes: &[u8]) -> MIME {
 fn match_filepath_noalias(mimetype: &str, filepath: &Path) -> bool {
     match CHECKER_SUPPORT.get(mimetype) {
         None => false,
-        Some(y) => (CHECKERS[*y].from_filepath)(filepath, mimetype),
+        Some(c) => c.from_filepath(&filepath, mimetype),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,11 +244,11 @@ fn graph_init() -> TypeStruct {
 }
 
 /// Just the part of from_*_node that walks the graph
-fn typegraph_walker<T: Clone>(
-    parentnode: NodeIndex,
-    input: T,
-    matchfn: fn(&str, T) -> bool,
-) -> Option<MIME> {
+fn typegraph_walker<T, F>(parentnode: NodeIndex, input: &T, matchfn: F) -> Option<MIME>
+where
+    T: ?Sized,
+    F: Fn(&str, &T) -> bool,
+{
     // Pull most common types towards top
     let mut children: Vec<NodeIndex> = TYPE
         .graph
@@ -267,7 +267,7 @@ fn typegraph_walker<T: Clone>(
     for childnode in children {
         let mimetype = &TYPE.graph[childnode];
 
-        let result = (matchfn)(mimetype, input.clone());
+        let result = matchfn(mimetype, input);
         match result {
             true => match typegraph_walker(childnode, input, matchfn) {
                 Some(foundtype) => return Some(foundtype),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ type MIME = &'static str;
 
 /// Check these types first
 /// TODO: Poll these from the checkers? Feels a bit arbitrary
-const TYPEORDER: [&'static str; 6] = [
+const TYPEORDER: [&str; 6] = [
     "image/png",
     "image/jpeg",
     "image/gif",
@@ -114,8 +114,8 @@ const CHECKERS: [CheckerStruct; CHECKERCOUNT] = [
 lazy_static! {
     static ref CHECKER_SUPPORT: FnvHashMap<MIME, usize> = {
         let mut out = FnvHashMap::<MIME, usize>::default();
-        for i in 0..CHECKERS.len() {
-            for j in (CHECKERS[i].get_supported)() {
+        for (i, c) in CHECKERS.iter().enumerate() {
+            for j in (c.get_supported)() {
                 out.insert(j, i);
             }
         }
@@ -126,8 +126,8 @@ lazy_static! {
 lazy_static! {
     static ref ALIASES: FnvHashMap<MIME, MIME> = {
         let mut out = FnvHashMap::<MIME, MIME>::default();
-        for i in 0..CHECKERS.len() {
-            out.extend((CHECKERS[i].get_aliaslist)());
+        for c in &CHECKERS {
+            out.extend((c.get_aliaslist)());
         }
         out
     };
@@ -159,11 +159,11 @@ fn graph_init() -> TypeStruct {
     // Get list of MIME types and MIME relations
     let mut mimelist = Vec::<MIME>::new();
     let mut edgelist_raw = Vec::<(MIME, MIME)>::new();
-    for i in 0..CHECKERS.len() {
-        mimelist.extend((CHECKERS[i].get_supported)());
-        edgelist_raw.extend((CHECKERS[i].get_subclasses)());
+    for c in &CHECKERS {
+        mimelist.extend((c.get_supported)());
+        edgelist_raw.extend((c.get_subclasses)());
     }
-    mimelist.sort();
+    mimelist.sort_unstable();
     mimelist.dedup();
     let mimelist = mimelist;
 
@@ -238,8 +238,8 @@ fn graph_init() -> TypeStruct {
 
     let mut edge_list_2 = FnvHashSet::<(NodeIndex, NodeIndex)>::default();
     for mimenode in graph.externals(Incoming) {
-        let ref mimetype = graph[mimenode];
-        let toplevel = mimetype.split("/").nth(0).unwrap_or("");
+        let mimetype = &graph[mimenode];
+        let toplevel = mimetype.split('/').next().unwrap_or("");
 
         if mimenode == node_text
             || mimenode == node_octet
@@ -285,7 +285,7 @@ fn typegraph_walker<T: Clone>(
 
     // Walk graph
     for childnode in children {
-        let ref mimetype = TYPE.graph[childnode];
+        let mimetype = &TYPE.graph[childnode];
 
         let result = (matchfn)(mimetype, input.clone());
         match result {


### PR DESCRIPTION
The commits below are all individually described in their commit messages.

In broad strokes:
- Run `cargo clippy` and resolve everything it brings up.
- Refacted `CheckerStruct` into a trait and use `dyn &` trait object pointers rather than an index into a bag of function pointers. 
- Use a generic bound on `typegraph_walker` rather than another opaque function pointer.