### PR TITLE
Upgrade nom to 7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 petgraph = "^0.5"
-nom = "6.0"
+nom = "7.0"
 lazy_static = "^1.4"
 fnv = "^1"
 bytecount = "^0.6"


### PR DESCRIPTION
Upgraded due to problem with crate compatibility in dependency graphs: https://github.com/Geal/nom/issues/1330