### PR TITLE
feat: support apple silicon homebrew path for shared-mime-info magic db

### DIFF
--- a/src/fdo_magic/builtin/runtime.rs
+++ b/src/fdo_magic/builtin/runtime.rs
@@ -15,6 +15,7 @@ fn search_paths(filename: &str) -> Vec<PathBuf> {
     let mut search_paths = vec![
         PathBuf::from("/usr/share/mime").join(filename),
         PathBuf::from("/usr/local/share/mime").join(filename),
+        PathBuf::from("//opt/homebrew/share/mime").join(filename),
     ];
     if let Some(home) = home::home_dir() {
         search_paths.push(home.join(".local/share/mime").join(filename));


### PR DESCRIPTION
Tests have been failing which require this crate, where `shared-mime-info` is installed on the new `macos-latest` arm64 runners, due to a lookup path which is populated on intel macs, but not apple silicon.

Some cross platform CI tests wouldn't go amiss in the repo, happy to add a pr