### PR TITLE
Handle loading MIME database from a specified dir

### DIFF
--- a/src/fdo_magic/builtin/runtime.rs
+++ b/src/fdo_magic/builtin/runtime.rs
@@ -20,6 +20,12 @@ fn mime_path(base: &Path, filename: &str) -> PathBuf {
 fn search_paths(filename: &str) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
+    // If the TREE_MAGIC_DIR environment variable is set, use it directly
+    // and return so we just use specified directory.
+    if let Some(load_path) = var_os("TREE_MAGIC_DIR") {
+        return vec![PathBuf::from(load_path).join(filename)];
+    }
+
     let data_dirs = match var_os("XDG_DATA_DIRS") {
         Some(dirs) if !dirs.is_empty() => dirs,
         _ => OsString::from("/usr/local/share/:/usr/share/"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@
 //! ## Licensing and the MIME database
 //!
 //! By default, `tree_magic_mini` will attempt to load the shared MIME info
-//! database from the standard locations at runtime.
+//! database from the standard locations at runtime. If the environment variable
+//! `TREE_MAGIC_DIR` is set, it will use that directory instead.
 //!
 //! If you won't have the database files available, or would like to include them
 //! in your binary for simplicity, you can optionally embed the database

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! # Features
 //!
-//! - Very fast perfomance (~150ns to check one file against one type,
+//! - Very fast performance (~150ns to check one file against one type,
 //!   between 5,000ns and 100,000ns to find a MIME type.)
 //! - Check if a file *is* a certain type.
 //! - Handles aliases (ex: `application/zip` vs `application/x-zip-compressed`)


### PR DESCRIPTION
This patch set adds the capability to specify the unique directory to load the MIME database from. By setting `TREE_MAGIC_DIR`  environment variable, the user can specify the directory where the MIME database is.

This is useful for predictability of analysis in the case the MIME database can not be embedded and/or if a software wants to keep a fixed version of the MIME database independently of the evolution of  `tree_magic_mini` crate. It then can do this by shipping its own file and setting the `TREE_MAGIC_DIR` environment variable.

This feature will allow integration of the crate in Suricata. See https://github.com/OISF/suricata/pull/13697 for more information.