### PR TITLE
Fix HTML DOCTYPE detection by merging duplicate MIME type rules

### DIFF
--- a/src/fdo_magic/ruleset.rs
+++ b/src/fdo_magic/ruleset.rs
@@ -101,9 +101,16 @@ fn gen_graph(magic_rules: Vec<MagicRule<'_>>) -> DiGraph<MagicRule<'_>, u32> {
 #[cfg(feature = "with-gpl-data")]
 pub fn from_u8(b: &[u8]) -> Result<HashMap<&str, DiGraph<MagicRule<'_>, u32>>, String> {
     let tuplevec = ruleset(b).map_err(|e| e.to_string())?.1;
-    let res = tuplevec
+
+    // Merge rules for MIME types with multiple priority levels
+    let mut merged_rules: HashMap<&str, Vec<MagicRule<'_>>> = HashMap::new();
+    for (mime, rules) in tuplevec {
+        merged_rules.entry(mime).or_insert_with(Vec::new).extend(rules);
+    }
+
+    let res = merged_rules
         .into_iter()
-        .map(|x| (x.0, gen_graph(x.1)))
+        .map(|(mime, rules)| (mime, gen_graph(rules)))
         .collect();
     Ok(res)
 }
@@ -117,9 +124,16 @@ pub fn from_multiple(
     for slice in files {
         tuplevec.append(&mut ruleset(slice.as_ref()).map_err(|e| e.to_string())?.1);
     }
-    let res = tuplevec
+
+    // Merge rules for MIME types with multiple priority levels
+    let mut merged_rules: HashMap<&str, Vec<MagicRule<'_>>> = HashMap::new();
+    for (mime, rules) in tuplevec {
+        merged_rules.entry(mime).or_insert_with(Vec::new).extend(rules);
+    }
+
+    let res = merged_rules
         .into_iter()
-        .map(|x| (x.0, gen_graph(x.1)))
+        .map(|(mime, rules)| (mime, gen_graph(rules)))
         .collect();
     Ok(res)
 }

--- a/tests/from_u8.rs
+++ b/tests/from_u8.rs
@@ -99,6 +99,42 @@ mod from_u8 {
     }
 
     #[test]
+    fn text_html_doctype_lowercase() {
+        let html = b"<!DOCTYPE html><html><body></body></html>";
+        assert_eq!(
+            tree_magic::from_u8(html),
+            convmime!("text/html")
+        );
+    }
+
+    #[test]
+    fn text_html_doctype_uppercase() {
+        let html = b"<!DOCTYPE HTML><html><body></body></html>";
+        assert_eq!(
+            tree_magic::from_u8(html),
+            convmime!("text/html")
+        );
+    }
+
+    #[test]
+    fn text_html_doctype_only() {
+        let html = b"<!DOCTYPE html>";
+        assert_eq!(
+            tree_magic::from_u8(html),
+            convmime!("text/html")
+        );
+    }
+
+    #[test]
+    fn text_html_doctype_with_newline() {
+        let html = b"<!DOCTYPE html>\n<html>\n<head><title>Test</title></head>\n<body></body>\n</html>";
+        assert_eq!(
+            tree_magic::from_u8(html),
+            convmime!("text/html")
+        );
+    }
+
+    #[test]
     fn text_plain() {
         assert_eq!(
             tree_magic::from_u8(include_bytes!("text/plain")),


### PR DESCRIPTION
# Fix DOCTYPE HTML detection

## Problem

HTML documents with `<!DOCTYPE html>` declarations were incorrectly identified as `text/plain` instead of `text/html`. This affected both lowercase (`<!DOCTYPE html>`) and uppercase (`<!DOCTYPE HTML>`) variants, despite the patterns existing in the magic database.

## Root Cause

The magic database contains multiple priority levels for certain MIME types (e.g., `[50:text/html]` and `[40:text/html]`). The parser in `src/fdo_magic/ruleset.rs` was collecting these entries into a HashMap, which caused later entries to overwrite earlier ones. This resulted in high-priority rules (including DOCTYPE patterns) being discarded.

## Solution

Modified `from_u8()` and `from_multiple()` in `src/fdo_magic/ruleset.rs` to:
1. Collect all rules into a temporary HashMap by MIME type
2. Merge rules for duplicate MIME types by extending their vectors
3. Generate graphs from the merged rule sets

This ensures all magic rules across different priority levels are properly loaded.

## Changes

- Modified `src/fdo_magic/ruleset.rs` to merge rules for MIME types with multiple priority levels
- Added comprehensive test coverage in `tests/from_u8.rs` for DOCTYPE detection variants

## Testing

All existing tests pass. New tests added:
- `text_html_doctype_lowercase` - HTML5 standard DOCTYPE
- `text_html_doctype_uppercase` - Uppercase variant
- `text_html_doctype_only` - Bare DOCTYPE declaration
- `text_html_doctype_with_newline` - Real-world formatted HTML

Tests pass both with and without the `with-gpl-data` feature.
