### PR TITLE
Add static and shared library support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
 graph.dot
 graph.svg
-
+.direnv
+result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ exclude = ["tests/*", "benches/*/"]
 edition = "2024"
 rust-version = "1.85"
 
+[lib]
+name = "tree_magic_mini"
+crate-type = ["cdylib", "staticlib"]
+
 [dependencies]
 petgraph = { version = "0.8.0", default-features = false }
 nom = "8.0"

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,7 @@
+# Add static and shared library support
+
+Adds support for building `tree_magic_mini` as static and shared libraries with C FFI bindings.
+
+- Added C FFI wrappers for all public APIs
+- Updated `Cargo.toml` to build `cdylib` and `staticlib` crate types
+- Added Nix package with C header generation via `cbindgen` and pkg-config support

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,8 @@
+language = "C"
+
+[struct]  
+derive_eq = true  
+
+[enum]  
+add_sentinel = true  
+prefix_with_name = true

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766902085,
+        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767062690,
+        "narHash": "sha256-hfKAOJQYbR0mlwabV56tOlEMUgESRroHqlDpX0hwOpU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "943d2d0bf1b86267287aff826ebd1138d83113b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,11 @@
   };
 
   outputs =
-    { nixpkgs, rust-overlay, ... }:
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+    }:
     let
       systems = [
         "x86_64-linux"
@@ -40,6 +44,11 @@
           };
           RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
         };
+      });
+
+      packages = forAllSystems (pkgs: {
+        tree_magic_mini = pkgs.callPackage ./nix/package.nix { };
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.tree_magic_mini;
       });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, rust-overlay, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      overlays = [
+        (import rust-overlay)
+        (self: super: {
+          rustToolchain = super.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rustfmt"
+            ];
+          };
+        })
+      ];
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs systems (system: function (import nixpkgs { inherit system overlays; }));
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          buildInputs = builtins.attrValues {
+            inherit (pkgs)
+              rustToolchain
+              rust-analyzer-unwrapped
+              ;
+          };
+          RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+        };
+      });
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,73 @@
+{
+  rustPlatform,
+  lib,
+  gcc,
+  stdenv,
+  rust-cbindgen,
+}:
+let
+  cargoToml = fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tree_magic_mini";
+  inherit (cargoToml.package) version;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+  };
+
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter =
+      p: type:
+      let
+        relPath = lib.removePrefix (toString ../. + "/") (toString p);
+      in
+      lib.any (p: lib.hasPrefix p relPath) [
+        "src"
+        "tests"
+        "magic_db"
+        "benches"
+        "cbindgen.toml"
+        "Cargo.toml"
+        "Cargo.lock"
+        "tree_magic_mini.pc.in"
+      ];
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    rust-cbindgen
+  ];
+
+  buildInputs = [
+    gcc
+  ];
+
+  postInstall = ''
+    mkdir -p $out/include  
+    cbindgen --config cbindgen.toml --crate tree_magic_mini --output $out/include/tree_magic_mini.h --lang C
+
+    mkdir -p $out/lib  
+    cp target/${stdenv.hostPlatform.rust.rustcTarget}/release/libtree_magic_mini${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib
+
+    mkdir -p $out/lib/pkgconfig
+
+    sed \
+      -e "s|@PREFIX@|$out|g" \
+      -e "s|@INCLUDE@|$out/include|g" \
+      -e "s|@LIBDIR@|$out/lib|g" \
+      -e "s|@VERSION@|${finalAttrs.version}|g" \
+      < ./tree_magic_mini.pc.in > $out/lib/pkgconfig/tree_magic_mini.pc
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Determines the MIME type of a file by traversing a filetype tree.";
+    homepage = "https://github.com/mbrubeck/tree_magic";
+    license = lib.licenses.gpl3;
+    maintainers = builtins.attrValues { inherit (lib.maintainers) r0chd; };
+    platforms = lib.platforms.all;
+  };
+})

--- a/tree_magic_mini.pc.in
+++ b/tree_magic_mini.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+includedir=@INCLUDE@
+libdir=@LIBDIR@
+
+Name: tree_magic_mini
+URL: https://github.com/mbrubeck/tree_magic
+Description: Determines the MIME type of a file by traversing a filetype tree.
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -ltree_magic_mini


### PR DESCRIPTION
Adds support for building `tree_magic_mini` as static and shared libraries with C FFI bindings.

- Added C FFI wrappers for all public APIs
- Updated `Cargo.toml` to build `cdylib` and `staticlib` crate types
- Added Nix package with C header generation via `cbindgen` and pkg-config support